### PR TITLE
Allow for integration tests in tests/ and cleanup the project setup.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [features]
 nightly = []
 
+[lib]
+name = "rush"
+
 [[bin]]
 name = "rush"
 path = "src/main.rs"

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -19,13 +19,11 @@
 // MA 02110-1301, USA.
 //
 
-/// RuSh indexed and associative arrays management is located in this module.
-///
-/// arrays.rs contains arrays structures and affiliated methods.
-/// `Array` is defined here.
-/// arrays (un)setting, and update methods for arrays.
-extern crate rand;
-extern crate seahash;
+//! RuSh indexed and associative arrays management is located in this module.
+//!
+//! arrays.rs contains arrays structures and affiliated methods.
+//! `Array` is defined here.
+//! arrays (un)setting, and update methods for arrays.
 
 use crate::variables::{Access, Value};
 use std::collections::HashMap;
@@ -72,8 +70,8 @@ impl Array {
     /// ```rust
     /// use std::collections::HashMap;
     /// use std::hash::BuildHasher;
-    /// use RuSh::variables::{Access, Value};
-    /// use RuSh::arrays::{Array, Index, SeaRandomState};
+    /// use rush::variables::{Access, Value};
+    /// use rush::arrays::{Array, Index, SeaRandomState};
     ///
     /// let mut arrayvars = Array {
     ///     arrayvars: HashMap::with_capacity_and_hasher(200, SeaRandomState),
@@ -155,8 +153,8 @@ impl Array {
     /// ```rust
     /// use std::collections::HashMap;
     /// use std::hash::BuildHasher;
-    /// use RuSh::variables::{Access, Value};
-    /// use RuSh::arrays::{Array, Index, SeaRandomState};
+    /// use rush::variables::{Access, Value};
+    /// use rush::arrays::{Array, Index, SeaRandomState};
     ///
     /// let mut arrayvars = Array {
     ///     arrayvars: HashMap::with_capacity_and_hasher(200, SeaRandomState),
@@ -218,8 +216,8 @@ impl Array {
     /// ```rust
     /// use std::collections::HashMap;
     /// use std::hash::BuildHasher;
-    /// use RuSh::variables::{Access, Value};
-    /// use RuSh::arrays::{Array, Index, SeaRandomState};
+    /// use rush::variables::{Access, Value};
+    /// use rush::arrays::{Array, Index, SeaRandomState};
     ///
     /// let mut arrayvars = Array {
     ///     arrayvars: HashMap::with_capacity_and_hasher(200, SeaRandomState),
@@ -250,8 +248,8 @@ impl Array {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Value};
-    /// use RuSh::arrays::{Array, Index};
+    /// use rush::variables::{Access, Value};
+    /// use rush::arrays::{Array, Index};
     ///
     /// let mut arrayvars = Array::init_shell_array_vars();
     /// match arrayvars.get("RUSH_ALIASES", &Index::A("egrep".to_string())) {
@@ -292,8 +290,8 @@ impl Array {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Value};
-    /// use RuSh::arrays::{Array, Index};
+    /// use rush::variables::{Access, Value};
+    /// use rush::arrays::{Array, Index};
     ///
     /// let mut arrayvars = Array::init_shell_array_vars();
     /// match arrayvars.get("RUSH_ALIASES", &Index::A("grep".to_string())) {
@@ -650,148 +648,5 @@ impl Array {
         //~ },
         //~ );
         arrayvars
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::arrays::{Array, Index};
-    use crate::variables::{Access, Value};
-
-    #[test]
-    fn test_init_shell_array_vars() {
-        let array = Array::init_shell_array_vars();
-        match array.get("RUSH_VERSINFO", &Index::I(1)) {
-            // RUSH_VERSINFO[1]=0
-            Some(v) => match v {
-                Value::I(i) => assert_eq!(i, 0),
-                _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
-            },
-            None => panic!("RUSH_VERSINFO[1] should be defined."),
-        }
-        match array.get("RUSH_VERSINFO", &Index::I(4)) {
-            Some(v) => match v {
-                Value::S(s) => assert_eq!(s, "alpha0"),
-                _ => panic!("RUSH_VERSINFO[4] should be Value::S."),
-            },
-            None => panic!("RUSH_VERSINFO[4] should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_unset() {
-        let mut array = Array::init_shell_array_vars();
-        match array.get("RUSH_VERSINFO", &Index::I(1)) {
-            Some(v) => match v {
-                Value::I(i) => assert_eq!(i, 0),
-                _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
-            },
-            None => panic!("RUSH_VERSINFO[1] should be defined."),
-        }
-        array.unset("RUSH_VERSINFO", &Index::I(1));
-        match array.get("RUSH_VERSINFO", &Index::I(1)) {
-            Some(_v) => panic!("RUSH_VERSINFO[1] should have been unset."),
-            None => println!("RUSH_VERSINFO[1] is not set."),
-        }
-    }
-
-    #[test]
-    fn test_get_and_getifs() {
-        let mut array = Array::init_shell_array_vars();
-        match array.get("RUSH_VERSINFO", &Index::I(4)) {
-            Some(v) => match v {
-                Value::S(s) => assert_eq!(s, "alpha0"),
-                _ => panic!("RUSH_VERSINFO[4] should be Value::S."),
-            },
-            None => panic!("RUSH_VERSINFO[4] should be defined."),
-        }
-        match array.get("RUSH_VERSINFO", &Index::I(1)) {
-            Some(v) => match v {
-                Value::I(i) => assert_eq!(i, 0),
-                _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
-            },
-            None => panic!("RUSH_VERSINFO[1] should be defined."),
-        }
-        array.set("TEST", Index::A("IT".to_string()), Value::F(-49.3));
-        match array.get("TEST", &Index::A("IT".to_string())) {
-            Some(v) => match v {
-                Value::F(f) => assert_eq!(f, -49.3),
-                _ => panic!("TEST[IT] should be Value::F."),
-            },
-            None => panic!("TEST[IT] variable should be defined."),
-        }
-        array.set("TEST", Index::I(0), Value::F(-49.3));
-        match array.get("TEST", &Index::I(0)) {
-            Some(v) => match v {
-                Value::F(f) => assert_eq!(f, -49.3),
-                _ => panic!("TEST[0] should be Value::F."),
-            },
-            None => panic!("TEST[0] variable should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_set_access() {
-        let mut array = Array::init_shell_array_vars();
-        array.set("TESTF", Index::A("BLA".to_string()), Value::F(-49.3));
-        array.set_access("TESTF", Access::ReadOnly);
-        assert_eq!(array.get_access("TESTF"), Some(Access::ReadOnly));
-        array.set_access("TESTF", Access::ReadWrite);
-        assert_eq!(array.get_access("TESTF"), Some(Access::ReadWrite));
-        match array.get("TESTF", &Index::A("BLA".to_string())) {
-            Some(f) => match f {
-                Value::F(f) => assert_eq!(f, -49.3),
-                _ => panic!("TESTF[\"BLA\"] should be Value::F."),
-            },
-            None => panic!("TESTF[\"BLA\"] variable should be defined."),
-        }
-        array.set_access("nonexistingentry", Access::ReadOnly);
-        assert_eq!(array.get_access("nonexistingentry"), Some(Access::ReadOnly));
-        array.set_access("nonexistingentry2", Access::ReadWrite);
-        assert_eq!(
-            array.get_access("nonexistingentry2"),
-            Some(Access::ReadWrite)
-        );
-        array.set("nonexistingentry2", Index::I(0), Value::I(1));
-        match array.get("nonexistingentry2", &Index::I(0)) {
-            Some(i) => match i {
-                Value::I(i) => assert_eq!(i, 1),
-                _ => panic!("nonexistingentry2[0] should be Value::I."),
-            },
-            None => panic!("nonexistingentry2[0] should be defined and Value::I."),
-        }
-    }
-
-    #[test]
-    fn test_set() {
-        let mut array = Array::init_shell_array_vars();
-        array.set("TESTF", Index::A("A".to_string()), Value::F(-49.3));
-        match array.get("TESTF", &Index::A("A".to_string())) {
-            Some(v) => match v {
-                Value::F(f) => assert_eq!(f, -49.3),
-                _ => panic!("TESTF[A] should be Value::F."),
-            },
-            None => panic!("TESTF[A] should be defined."),
-        }
-        array.set("TESTI", Index::I(42), Value::I(-42));
-        match array.get("TESTI", &Index::I(42)) {
-            Some(v) => match v {
-                Value::I(i) => assert_eq!(i, -42),
-                _ => panic!("TESTI[42] should be Value::I."),
-            },
-            None => panic!("TESTI[42] should be defined."),
-        }
-        array.set(
-            "TESTS",
-            Index::A("or not".to_string()),
-            Value::S(String::from("RuSh will rock (one day)")),
-        );
-        match array.get("TESTS", &Index::A("or not".to_string())) {
-            Some(v) => match v {
-                Value::S(s) => assert_eq!(s, "RuSh will rock (one day)"),
-                _ => panic!("TESTS[or not] should be Value::I."),
-            },
-            None => panic!("TESTS[or not] array should be defined."),
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,19 @@
+//! The RuSh library crate.
+
+extern crate chrono;
+extern crate pest;
+extern crate rand;
+extern crate seahash;
+
+/// Include arrays management.
+pub mod arrays;
+/// Include options management (shopt, set)
+pub mod opt;
+/// Include prompt management.
+pub mod prompt;
+/// Include rush core.
+pub mod rush;
+/// Include variables management.
+pub mod variables;
+
+pub use self::rush::RuSh;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,16 +27,6 @@
 //! That does not mean feedback or patches are not welcome.
 //! Right now, RuSh is definitely not useable. A couple little things have been done, but 99% (at least) have to be written.
 
-/// Include arrays management.
-mod arrays;
-/// Include options management (shopt, set)
-mod opt;
-/// Include prompt management.
-mod prompt;
-/// Include rush core.
-mod rush;
-/// Include variables management.
-mod variables;
 
 extern crate chrono;
 extern crate libc;
@@ -47,16 +37,17 @@ extern crate seahash;
 extern crate term;
 #[macro_use]
 extern crate pest_derive;
+extern crate rush;
 extern crate structopt;
 extern crate structopt_derive;
 
 use pest::Parser;
 // pub for use is there so doc is generated.
-pub use crate::arrays::Array;
-pub use crate::opt::Opt;
-pub use crate::prompt::Prompt;
-pub use crate::rush::RuSh;
-pub use crate::variables::Variables;
+pub use rush::arrays::Array;
+pub use rush::opt::Opt;
+pub use rush::prompt::Prompt;
+pub use rush::rush::RuSh;
+pub use rush::variables::Variables;
 
 // pest grammar inclusion. dummy const so that .pest file changes are taken care of.
 #[derive(Parser)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -19,11 +19,10 @@
 // MA 02110-1301, USA.
 //
 
-/// RuSh opt (shopt, set) management begins here.
-///
-/// opt.rs contains OptionRW and Opt structures and affiliated methods.
-/// opt (un)setting, update methods for both shopt and options.
-extern crate seahash;
+//! RuSh opt (shopt, set) management begins here.
+//!
+//! opt.rs contains OptionRW and Opt structures and affiliated methods.
+//! opt (un)setting, update methods for both shopt and options.
 
 use crate::variables::{Access, SeaRandomState};
 use std::collections::HashMap;
@@ -56,8 +55,8 @@ impl Opt {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::opt::Opt;
-    /// use RuSh::variables::{Access, SeaRandomState};
+    /// use rush::opt::Opt;
+    /// use rush::variables::{Access, SeaRandomState};
     /// let mut o = Opt::init_set_options();
     /// match o.get("notify") {
     ///     Some(v) => { assert_eq!(v.set, false); assert_eq!(v.access, Access::ReadWrite); },
@@ -81,9 +80,9 @@ impl Opt {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::opt::Opt;
-    /// use RuSh::opt::OptionRW;
-    /// use RuSh::variables::{Access, SeaRandomState};
+    /// use rush::opt::Opt;
+    /// use rush::opt::OptionRW;
+    /// use rush::variables::{Access, SeaRandomState};
     /// let mut o = Opt::init_shopt_options();
     /// o.set(String::from("opttest"), OptionRW { set: false, access: Access::ReadOnly });
     /// match o.get("opttest") {
@@ -679,67 +678,5 @@ impl Opt {
             },
         );
         options
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::opt::Opt;
-    use crate::opt::OptionRW;
-    use crate::variables::Access;
-
-    #[test]
-    fn test_opt_get() {
-        let o = Opt::init_set_options();
-        match o.get("notify") {
-            Some(v) => {
-                assert_eq!(v.set, false);
-                assert_eq!(v.access, Access::ReadWrite);
-            }
-            None => panic!("notify set option should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_opt_init_set_options() {
-        let o = Opt::init_set_options();
-        match o.get("xtrace") {
-            Some(v) => {
-                assert_eq!(v.set, false);
-                assert_eq!(v.access, Access::ReadWrite);
-            }
-            None => panic!("xtrace set option should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_opt_init_shopt_options() {
-        let o = Opt::init_shopt_options();
-        match o.get("histappend") {
-            Some(v) => {
-                assert_eq!(v.set, true);
-                assert_eq!(v.access, Access::ReadWrite);
-            }
-            None => panic!("histappend shopt option should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_opt_set() {
-        let mut o = Opt::init_shopt_options();
-        o.set(
-            String::from("opttest"),
-            OptionRW {
-                set: false,
-                access: Access::ReadOnly,
-            },
-        );
-        match o.get("opttest") {
-            Some(v) => {
-                assert_eq!(v.set, false);
-                assert_eq!(v.access, Access::ReadOnly);
-            }
-            None => panic!("opttest shopt option should be defined."),
-        }
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -19,18 +19,15 @@
 // MA 02110-1301, USA.
 //
 
-/// RuSh prompt management begins here.
-///
-/// prompt.rs contains prompt affiliated methods.
-/// prompt is parsed here too.
-extern crate chrono;
-extern crate pest;
-extern crate rand;
+//! RuSh prompt management begins here.
+//!
+//! prompt.rs contains prompt affiliated methods.
+//! prompt is parsed here too.
 
-use self::chrono::*;
-use crate::prompt::pest::Parser;
+use chrono::*;
 use crate::rush::RuSh;
 use crate::variables::{Access, Value, Variable};
+use pest::Parser;
 use pest_derive::Parser;
 
 /// pest grammar inclusion. dummy const so that .pest file changes are taken care of.
@@ -50,10 +47,10 @@ impl Prompt {
     ///
     /// # Examples
     /// ```rust
-    /// use crate::RuSh;
-    /// use RuSh::prompt::Prompt;
-    /// use RuSh::variables::{Variables, Variable, Value};
-    /// let mut r = RuSh::rush::RuSh::default();
+    /// use rush::RuSh;
+    /// use rush::prompt::Prompt;
+    /// use rush::variables::{Variables, Variable, Value};
+    /// let mut r = RuSh::default();
     /// let mut p = Prompt::get(&mut r, "PS2");
     /// assert_eq!(p.prompt, ">");
     /// p = Prompt::get(&mut r, "PS3");
@@ -223,22 +220,5 @@ impl Prompt {
             };
         }
         Prompt { prompt: pt }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::prompt::Prompt;
-    use crate::rush::RuSh;
-
-    #[test]
-    fn test_get() {
-        let mut rush = RuSh::default();
-        let mut p = Prompt::get(&mut rush, "PS2");
-        assert_eq!(p.prompt, ">");
-        p = Prompt::get(&mut rush, "PS3");
-        assert_eq!(p.prompt, ">");
-        p = Prompt::get(&mut rush, "PS4");
-        assert_eq!(p.prompt, ">");
     }
 }

--- a/src/rush.rs
+++ b/src/rush.rs
@@ -19,8 +19,6 @@
 // MA 02110-1301, USA.
 //
 
-extern crate pest;
-
 pub use crate::arrays::Array;
 pub use crate::opt::Opt;
 pub use crate::prompt::Prompt;

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -19,15 +19,13 @@
 // MA 02110-1301, USA.
 //
 
-/// RuSh variables management is located in this module.
-///
-/// variables.rs contains variables structures and affiliated methods.
-/// `Variable` and `Variables` are defined here.
-/// variables (un)setting, update methods for classical variables.
-extern crate rand;
-extern crate seahash;
+//! RuSh variables management is located in this module.
+//!
+//! variables.rs contains variables structures and affiliated methods.
+//! `Variable` and `Variables` are defined here.
+//! variables (un)setting, update methods for classical variables.
 
-use self::rand::Rng;
+use rand::Rng;
 use libc::{c_char, c_int, geteuid, getgid, getlogin, getpid, getppid, getuid, size_t};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
@@ -79,7 +77,7 @@ impl Variable {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Value};
+    /// use rush::variables::{Access, Variable, Value};
     /// let var = Variable { value: Value::I(-42), access: Access::ReadWrite };
     /// assert_eq!(var.geti(), -42);
     /// ```
@@ -94,7 +92,7 @@ impl Variable {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Value};
+    /// use rush::variables::{Access, Variable, Value};
     /// let var = Variable { value: Value::F(-42.5), access: Access::ReadWrite };
     /// assert_eq!(var.getf(), -42.5);
     /// ```
@@ -109,7 +107,7 @@ impl Variable {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Value};
+    /// use rush::variables::{Access, Variable, Value};
     /// let var = Variable { value: Value::S("Forty two".to_string()), access: Access::ReadWrite };
     /// assert_eq!(var.gets(), "Forty two");
     /// ```
@@ -133,7 +131,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Variables, Value};
+    /// use rush::variables::{Access, Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// match vars.get("RUSH_COMMAND") {
@@ -167,7 +165,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Variables, Value};
+    /// use rush::variables::{Access, Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// match vars.get_access("RUSH_COMMAND") {
@@ -194,7 +192,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Variables, Value};
+    /// use rush::variables::{Access, Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// vars.set(String::from("TESTF"), Variable { value: Value::F(-49.3), access: Access::ReadWrite });
@@ -232,7 +230,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Variables, Value};
+    /// use rush::variables::{Access, Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// vars.set_access("TEST".to_string(), Access::ReadWrite);
@@ -273,7 +271,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Variable, Variables, Value};
+    /// use rush::variables::{Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// match vars.get("RUSH_COMMAND") {
@@ -295,7 +293,7 @@ impl Variables {
     ///
     /// # Examples
     /// ```rust
-    /// use RuSh::variables::{Access, Variable, Variables, Value};
+    /// use rush::variables::{Access, Variable, Variables, Value};
     ///
     /// let mut vars = Variables::init_shell_vars();
     /// match vars.get("RUSH") {
@@ -596,142 +594,5 @@ impl Variables {
             },
         );
         vars
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    //use crate::variables::Variables;
-    use crate::variables::{Access, Value, Variable, Variables};
-
-    #[test]
-    fn test_init_shell_vars() {
-        let vars = Variables::init_shell_vars();
-        match vars.get("RUSH_COMMAND") {
-            Some(v) => assert_eq!(v.gets(), ""),
-            None => panic!("RUSH_COMMAND should be defined."),
-        }
-        match vars.get("HISTSIZE") {
-            Some(v) => assert_eq!(v.geti(), 1000),
-            None => panic!("HISTSIZE should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_unset() {
-        let mut vars = Variables::init_shell_vars();
-        match vars.get("RUSH_COMMAND") {
-            Some(v) => assert_eq!(v.gets(), ""),
-            None => panic!("RUSH_COMMAND should be defined."),
-        }
-        vars.unset(String::from("RUSH_COMMAND"));
-        match vars.get("RUSH_COMMAND") {
-            Some(_v) => panic!("RUSH_COMMAND should have been unset."),
-            None => println!("RUSH_COMMAND is not set."),
-        }
-    }
-
-    #[test]
-    fn test_get_and_getifs() {
-        let mut vars = Variables::init_shell_vars();
-        match vars.get("RUSH_COMMAND") {
-            Some(v) => assert_eq!(v.gets(), ""),
-            None => panic!("RUSH_COMMAND should be defined."),
-        }
-        match vars.get("HISTSIZE") {
-            Some(v) => assert_eq!(v.geti(), 1000),
-            None => panic!("HISTSIZE should be defined."),
-        }
-        vars.set(
-            String::from("TEST"),
-            Variable {
-                value: Value::F(-49.3),
-                access: Access::ReadWrite,
-            },
-        );
-        match vars.get("TEST") {
-            Some(v) => assert_eq!(v.getf(), -49.3),
-            None => panic!("TEST variable should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_set() {
-        let mut vars = Variables::init_shell_vars();
-        vars.set(
-            String::from("TESTF"),
-            Variable {
-                value: Value::F(-49.3),
-                access: Access::ReadWrite,
-            },
-        );
-        match vars.get("TESTF") {
-            Some(v) => assert_eq!(v.getf(), -49.3),
-            None => panic!("TESTF should be defined."),
-        }
-        vars.set(
-            String::from("TESTI"),
-            Variable {
-                value: Value::I(-42),
-                access: Access::ReadWrite,
-            },
-        );
-        match vars.get("TESTI") {
-            Some(v) => assert_eq!(v.geti(), -42),
-            None => panic!("TESTI should be defined."),
-        }
-        vars.set(
-            String::from("TESTS"),
-            Variable {
-                value: Value::S(String::from("RuSh will rock (one day)")),
-                access: Access::ReadWrite,
-            },
-        );
-        match vars.get("TESTS") {
-            Some(v) => assert_eq!(v.gets(), "RuSh will rock (one day)"),
-            None => panic!("TESTS variable should be defined."),
-        }
-    }
-
-    #[test]
-    fn test_get_access() {
-        let vars = Variables::init_shell_vars();
-        match vars.get_access("RUSH_COMMAND") {
-            Some(v) => assert_eq!(v, Access::ReadWrite),
-            None => panic!("RUSH_COMMAND should be defined and Access::ReadWrite."),
-        }
-        match vars.get_access("EUID") {
-            Some(v) => assert_eq!(v, Access::ReadOnly),
-            None => panic!("EUID should be defined and Access::ReadOnly."),
-        }
-        match vars.get_access("nonexistingvar") {
-            Some(v) => panic!("nonexistingvar should not give back {:?}", v),
-            None => assert!(true),
-        }
-    }
-
-    #[test]
-    fn test_set_access() {
-        let mut vars = Variables::init_shell_vars();
-        vars.set_access("TEST".to_string(), Access::ReadWrite);
-        match vars.get_access("TEST") {
-            Some(v) => assert_eq!(v, Access::ReadWrite),
-            None => panic!("TEST should be defined."),
-        }
-        vars.set_access("TEST".to_string(), Access::ReadOnly);
-        match vars.get_access("TEST") {
-            Some(v) => assert_eq!(v, Access::ReadOnly),
-            None => panic!("TEST should be defined."),
-        }
-        vars.set_access("doesnotexist".to_string(), Access::ReadWrite);
-        match vars.get_access("doesnotexist") {
-            Some(v) => assert_eq!(v, Access::ReadWrite),
-            None => panic!("doesnotexist variable should be defined and Access::ReadWrite"),
-        }
-        vars.set_access("doesnotexist2".to_string(), Access::ReadOnly);
-        match vars.get_access("doesnotexist2") {
-            Some(v) => assert_eq!(v, Access::ReadOnly),
-            None => panic!("doesnotexist variable should be defined and Access::ReadOnly"),
-        }
     }
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,0 +1,142 @@
+extern crate rush;
+
+use rush::arrays::{Array, Index};
+use rush::variables::{Access, Value};
+
+#[test]
+fn test_init_shell_array_vars() {
+    let array = Array::init_shell_array_vars();
+    match array.get("RUSH_VERSINFO", &Index::I(1)) {
+        // RUSH_VERSINFO[1]=0
+        Some(v) => match v {
+            Value::I(i) => assert_eq!(i, 0),
+            _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
+        },
+        None => panic!("RUSH_VERSINFO[1] should be defined."),
+    }
+    match array.get("RUSH_VERSINFO", &Index::I(4)) {
+        Some(v) => match v {
+            Value::S(s) => assert_eq!(s, "alpha0"),
+            _ => panic!("RUSH_VERSINFO[4] should be Value::S."),
+        },
+        None => panic!("RUSH_VERSINFO[4] should be defined."),
+    }
+}
+
+#[test]
+fn test_unset() {
+    let mut array = Array::init_shell_array_vars();
+    match array.get("RUSH_VERSINFO", &Index::I(1)) {
+        Some(v) => match v {
+            Value::I(i) => assert_eq!(i, 0),
+            _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
+        },
+        None => panic!("RUSH_VERSINFO[1] should be defined."),
+    }
+    array.unset("RUSH_VERSINFO", &Index::I(1));
+    match array.get("RUSH_VERSINFO", &Index::I(1)) {
+        Some(_v) => panic!("RUSH_VERSINFO[1] should have been unset."),
+        None => println!("RUSH_VERSINFO[1] is not set."),
+    }
+}
+
+#[test]
+fn test_get_and_getifs() {
+    let mut array = Array::init_shell_array_vars();
+    match array.get("RUSH_VERSINFO", &Index::I(4)) {
+        Some(v) => match v {
+            Value::S(s) => assert_eq!(s, "alpha0"),
+            _ => panic!("RUSH_VERSINFO[4] should be Value::S."),
+        },
+        None => panic!("RUSH_VERSINFO[4] should be defined."),
+    }
+    match array.get("RUSH_VERSINFO", &Index::I(1)) {
+        Some(v) => match v {
+            Value::I(i) => assert_eq!(i, 0),
+            _ => panic!("RUSH_VERSINFO[1] should be Value::I."),
+        },
+        None => panic!("RUSH_VERSINFO[1] should be defined."),
+    }
+    array.set("TEST", Index::A("IT".to_string()), Value::F(-49.3));
+    match array.get("TEST", &Index::A("IT".to_string())) {
+        Some(v) => match v {
+            Value::F(f) => assert_eq!(f, -49.3),
+            _ => panic!("TEST[IT] should be Value::F."),
+        },
+        None => panic!("TEST[IT] variable should be defined."),
+    }
+    array.set("TEST", Index::I(0), Value::F(-49.3));
+    match array.get("TEST", &Index::I(0)) {
+        Some(v) => match v {
+            Value::F(f) => assert_eq!(f, -49.3),
+            _ => panic!("TEST[0] should be Value::F."),
+        },
+        None => panic!("TEST[0] variable should be defined."),
+    }
+}
+
+#[test]
+fn test_set_access() {
+    let mut array = Array::init_shell_array_vars();
+    array.set("TESTF", Index::A("BLA".to_string()), Value::F(-49.3));
+    array.set_access("TESTF", Access::ReadOnly);
+    assert_eq!(array.get_access("TESTF"), Some(Access::ReadOnly));
+    array.set_access("TESTF", Access::ReadWrite);
+    assert_eq!(array.get_access("TESTF"), Some(Access::ReadWrite));
+    match array.get("TESTF", &Index::A("BLA".to_string())) {
+        Some(f) => match f {
+            Value::F(f) => assert_eq!(f, -49.3),
+            _ => panic!("TESTF[\"BLA\"] should be Value::F."),
+        },
+        None => panic!("TESTF[\"BLA\"] variable should be defined."),
+    }
+    array.set_access("nonexistingentry", Access::ReadOnly);
+    assert_eq!(array.get_access("nonexistingentry"), Some(Access::ReadOnly));
+    array.set_access("nonexistingentry2", Access::ReadWrite);
+    assert_eq!(
+        array.get_access("nonexistingentry2"),
+        Some(Access::ReadWrite)
+    );
+    array.set("nonexistingentry2", Index::I(0), Value::I(1));
+    match array.get("nonexistingentry2", &Index::I(0)) {
+        Some(i) => match i {
+            Value::I(i) => assert_eq!(i, 1),
+            _ => panic!("nonexistingentry2[0] should be Value::I."),
+        },
+        None => panic!("nonexistingentry2[0] should be defined and Value::I."),
+    }
+}
+
+#[test]
+fn test_set() {
+    let mut array = Array::init_shell_array_vars();
+    array.set("TESTF", Index::A("A".to_string()), Value::F(-49.3));
+    match array.get("TESTF", &Index::A("A".to_string())) {
+        Some(v) => match v {
+            Value::F(f) => assert_eq!(f, -49.3),
+            _ => panic!("TESTF[A] should be Value::F."),
+        },
+        None => panic!("TESTF[A] should be defined."),
+    }
+    array.set("TESTI", Index::I(42), Value::I(-42));
+    match array.get("TESTI", &Index::I(42)) {
+        Some(v) => match v {
+            Value::I(i) => assert_eq!(i, -42),
+            _ => panic!("TESTI[42] should be Value::I."),
+        },
+        None => panic!("TESTI[42] should be defined."),
+    }
+    array.set(
+        "TESTS",
+        Index::A("or not".to_string()),
+        Value::S(String::from("RuSh will rock (one day)")),
+        );
+    match array.get("TESTS", &Index::A("or not".to_string())) {
+        Some(v) => match v {
+            Value::S(s) => assert_eq!(s, "RuSh will rock (one day)"),
+            _ => panic!("TESTS[or not] should be Value::I."),
+        },
+        None => panic!("TESTS[or not] array should be defined."),
+    }
+}
+

--- a/tests/opt.rs
+++ b/tests/opt.rs
@@ -1,0 +1,61 @@
+extern crate rush;
+
+use rush::opt::Opt;
+use rush::opt::OptionRW;
+use rush::variables::Access;
+
+#[test]
+fn test_opt_get() {
+    let o = Opt::init_set_options();
+    match o.get("notify") {
+        Some(v) => {
+            assert_eq!(v.set, false);
+            assert_eq!(v.access, Access::ReadWrite);
+        }
+        None => panic!("notify set option should be defined."),
+    }
+}
+
+#[test]
+fn test_opt_init_set_options() {
+    let o = Opt::init_set_options();
+    match o.get("xtrace") {
+        Some(v) => {
+            assert_eq!(v.set, false);
+            assert_eq!(v.access, Access::ReadWrite);
+        }
+        None => panic!("xtrace set option should be defined."),
+    }
+}
+
+#[test]
+fn test_opt_init_shopt_options() {
+    let o = Opt::init_shopt_options();
+    match o.get("histappend") {
+        Some(v) => {
+            assert_eq!(v.set, true);
+            assert_eq!(v.access, Access::ReadWrite);
+        }
+        None => panic!("histappend shopt option should be defined."),
+    }
+}
+
+#[test]
+fn test_opt_set() {
+    let mut o = Opt::init_shopt_options();
+    o.set(
+        String::from("opttest"),
+        OptionRW {
+            set: false,
+            access: Access::ReadOnly,
+        },
+        );
+    match o.get("opttest") {
+        Some(v) => {
+            assert_eq!(v.set, false);
+            assert_eq!(v.access, Access::ReadOnly);
+        }
+        None => panic!("opttest shopt option should be defined."),
+    }
+}
+

--- a/tests/prompt.rs
+++ b/tests/prompt.rs
@@ -1,0 +1,16 @@
+extern crate rush;
+
+use rush::prompt::Prompt;
+use rush::rush::RuSh;
+
+#[test]
+fn test_get() {
+    let mut rush = RuSh::default();
+    let mut p = Prompt::get(&mut rush, "PS2");
+    assert_eq!(p.prompt, ">");
+    p = Prompt::get(&mut rush, "PS3");
+    assert_eq!(p.prompt, ">");
+    p = Prompt::get(&mut rush, "PS4");
+    assert_eq!(p.prompt, ">");
+}
+

--- a/tests/variables.rs
+++ b/tests/variables.rs
@@ -1,0 +1,136 @@
+extern crate rush;
+
+//use crate::variables::Variables;
+use rush::variables::{Access, Value, Variable, Variables};
+
+#[test]
+fn test_init_shell_vars() {
+    let vars = Variables::init_shell_vars();
+    match vars.get("RUSH_COMMAND") {
+        Some(v) => assert_eq!(v.gets(), ""),
+        None => panic!("RUSH_COMMAND should be defined."),
+    }
+    match vars.get("HISTSIZE") {
+        Some(v) => assert_eq!(v.geti(), 1000),
+        None => panic!("HISTSIZE should be defined."),
+    }
+}
+
+#[test]
+fn test_unset() {
+    let mut vars = Variables::init_shell_vars();
+    match vars.get("RUSH_COMMAND") {
+        Some(v) => assert_eq!(v.gets(), ""),
+        None => panic!("RUSH_COMMAND should be defined."),
+    }
+    vars.unset(String::from("RUSH_COMMAND"));
+    match vars.get("RUSH_COMMAND") {
+        Some(_v) => panic!("RUSH_COMMAND should have been unset."),
+        None => println!("RUSH_COMMAND is not set."),
+    }
+}
+
+#[test]
+fn test_get_and_getifs() {
+    let mut vars = Variables::init_shell_vars();
+    match vars.get("RUSH_COMMAND") {
+        Some(v) => assert_eq!(v.gets(), ""),
+        None => panic!("RUSH_COMMAND should be defined."),
+    }
+    match vars.get("HISTSIZE") {
+        Some(v) => assert_eq!(v.geti(), 1000),
+        None => panic!("HISTSIZE should be defined."),
+    }
+    vars.set(
+        String::from("TEST"),
+        Variable {
+            value: Value::F(-49.3),
+            access: Access::ReadWrite,
+        },
+        );
+    match vars.get("TEST") {
+        Some(v) => assert_eq!(v.getf(), -49.3),
+        None => panic!("TEST variable should be defined."),
+    }
+}
+
+#[test]
+fn test_set() {
+    let mut vars = Variables::init_shell_vars();
+    vars.set(
+        String::from("TESTF"),
+        Variable {
+            value: Value::F(-49.3),
+            access: Access::ReadWrite,
+        },
+        );
+    match vars.get("TESTF") {
+        Some(v) => assert_eq!(v.getf(), -49.3),
+        None => panic!("TESTF should be defined."),
+    }
+    vars.set(
+        String::from("TESTI"),
+        Variable {
+            value: Value::I(-42),
+            access: Access::ReadWrite,
+        },
+        );
+    match vars.get("TESTI") {
+        Some(v) => assert_eq!(v.geti(), -42),
+        None => panic!("TESTI should be defined."),
+    }
+    vars.set(
+        String::from("TESTS"),
+        Variable {
+            value: Value::S(String::from("RuSh will rock (one day)")),
+            access: Access::ReadWrite,
+        },
+        );
+    match vars.get("TESTS") {
+        Some(v) => assert_eq!(v.gets(), "RuSh will rock (one day)"),
+        None => panic!("TESTS variable should be defined."),
+    }
+}
+
+#[test]
+fn test_get_access() {
+    let vars = Variables::init_shell_vars();
+    match vars.get_access("RUSH_COMMAND") {
+        Some(v) => assert_eq!(v, Access::ReadWrite),
+        None => panic!("RUSH_COMMAND should be defined and Access::ReadWrite."),
+    }
+    match vars.get_access("EUID") {
+        Some(v) => assert_eq!(v, Access::ReadOnly),
+        None => panic!("EUID should be defined and Access::ReadOnly."),
+    }
+    match vars.get_access("nonexistingvar") {
+        Some(v) => panic!("nonexistingvar should not give back {:?}", v),
+        None => assert!(true),
+    }
+}
+
+#[test]
+fn test_set_access() {
+    let mut vars = Variables::init_shell_vars();
+    vars.set_access("TEST".to_string(), Access::ReadWrite);
+    match vars.get_access("TEST") {
+        Some(v) => assert_eq!(v, Access::ReadWrite),
+        None => panic!("TEST should be defined."),
+    }
+    vars.set_access("TEST".to_string(), Access::ReadOnly);
+    match vars.get_access("TEST") {
+        Some(v) => assert_eq!(v, Access::ReadOnly),
+        None => panic!("TEST should be defined."),
+    }
+    vars.set_access("doesnotexist".to_string(), Access::ReadWrite);
+    match vars.get_access("doesnotexist") {
+        Some(v) => assert_eq!(v, Access::ReadWrite),
+        None => panic!("doesnotexist variable should be defined and Access::ReadWrite"),
+    }
+    vars.set_access("doesnotexist2".to_string(), Access::ReadOnly);
+    match vars.get_access("doesnotexist2") {
+        Some(v) => assert_eq!(v, Access::ReadOnly),
+        None => panic!("doesnotexist variable should be defined and Access::ReadOnly"),
+    }
+}
+


### PR DESCRIPTION
  - Cleanup the usage of “extern crate” by gathering them in lib.rs.
  - Added the library crate “rush”.
  - Move tests into tests/.